### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 An MCP (Model Context Protocol) server for executing macOS terminal commands with ZSH shell. This server provides a secure way to execute shell commands with built-in whitelisting and approval mechanisms.
 
+<a href="https://glama.ai/mcp/servers/@cfdude/mac-shell-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@cfdude/mac-shell-mcp/badge" alt="Mac Shell Server MCP server" />
+</a>
+
 ## Features
 
 - Execute macOS terminal commands through MCP


### PR DESCRIPTION
This PR adds a badge for the [Mac Shell MCP Server](https://glama.ai/mcp/servers/@cfdude/mac-shell-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@cfdude/mac-shell-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@cfdude/mac-shell-mcp/badge" alt="Mac Shell Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.