### PR TITLE
chore(deps): Fix dependency security vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2103,9 +2103,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2536,9 +2536,9 @@
       }
     },
     "node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -3535,9 +3535,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.11.5",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.5.tgz",
-      "integrity": "sha512-WemPi9/WfyMwZs+ZUXdiwcCh9Y+m7L+8vki9MzDw3jJ+W9Lc+12HGsd368Qc1vZi1xwW8BWMMsnK5efYKPdt4g==",
+      "version": "4.11.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.7.tgz",
+      "integrity": "sha512-l7qMiNee7t82bH3SeyUCt9UF15EVmaBvsppY2zQtrbIhl/yzBTny+YUxsVjSjQ6gaqaeVtZmGocom8TzBlA4Yw==",
       "license": "MIT",
       "peer": true,
       "engines": {


### PR DESCRIPTION
## Summary
Updates dependencies to resolve security vulnerabilities identified by npm audit.

### Vulnerabilities Fixed
- **brace-expansion** (1.0.0 - 1.1.11): Regular Expression Denial of Service vulnerability (GHSA-v6h2-p8h4-qcjw)
- **diff** (4.0.0 - 4.0.3): Denial of Service vulnerability in parsePatch and applyPatch (GHSA-73rr-hh4g-fpgx)
- **hono** (<=4.11.6): Multiple vulnerabilities:
  - XSS through ErrorBoundary component (GHSA-9r54-q6cx-xmh5)
  - Arbitrary Key Read in Serve static Middleware (GHSA-w332-q679-j88p)
  - Cache middleware ignores Cache-Control: private (GHSA-6wqw-2p9w-4vw4)
  - IPv4 address validation bypass in IP Restriction Middleware (GHSA-r354-f388-2fhh)

## Test Plan
- [x] Ran `npm audit` - 0 vulnerabilities remaining
- [x] Ran `npm run lint` - passes
- [ ] `npm test` - 1 pre-existing test failure (not introduced by this PR)

**Note**: The test failure in `should queue command requiring approval` exists in main branch and is unrelated to these dependency updates.