### PR TITLE
fix: bump hono to 4.12.2 (CVE-2026-27700)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3459,9 +3459,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.0.tgz",
-      "integrity": "sha512-NekXntS5M94pUfiVZ8oXXK/kkri+5WpX2/Ik+LVsl+uvw+soj4roXIsPqO+XsWrAw20mOzaXOZf3Q7PfB9A/IA==",
+      "version": "4.12.8",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
+      "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/package.json
+++ b/package.json
@@ -47,6 +47,9 @@
     "@modelcontextprotocol/sdk": "^1.6.1",
     "zod": "^3.22.4"
   },
+  "overrides": {
+    "hono": "^4.12.2"
+  },
   "devDependencies": {
     "@types/jest": "^29.5.11",
     "@types/node": "^20.11.0",


### PR DESCRIPTION
## Summary

- Adds `overrides` in `package.json` to force `hono >= ^4.12.2`
- Resolves CVE-2026-27700; hono is a transitive dependency via `@modelcontextprotocol/sdk`
- Lock file regenerated; resolved to hono 4.12.8

## Changes

- `package.json`: added `"overrides": { "hono": "^4.12.2" }`
- `package-lock.json`: regenerated with hono 4.12.8