### PR TITLE
docs(2.0): rewrite docs and packaging for the new model

### DIFF
--- a/.mac-shell-mcp.sample.json
+++ b/.mac-shell-mcp.sample.json
@@ -1,0 +1,66 @@
+{
+  "_comment": "Copy to ~/.mac-shell-mcp/config.json, edit, then: chmod 444 ~/.mac-shell-mcp/config.json",
+
+  "allowedRoots": ["/Users/you/Projects/my-project"],
+
+  "_roots_note": "A root must be a project directory. The home directory and / are refused: confinement makes everything inside a root freely readable by one recursive search. Everything outside the roots requires execute_external_command, which needs an interactive client.",
+
+  "programDirectories": ["/usr/bin", "/bin", "/usr/sbin", "/sbin"],
+
+  "_programDirectories_note": "Programs resolve only from here, matched by resolved path. A directory with an unprivileged write path is refused: a writable program directory lets any write primitive author a program that resolves as a permitted command.",
+
+  "commands": {
+    "ls": {
+      "program": "/bin/ls",
+      "effect": "read",
+      "allowedArgs": ["-l", "-a", "-h", "-t", "-r", "-1"],
+      "permission": "allow"
+    },
+    "pwd": { "program": "/bin/pwd", "effect": "read", "allowedArgs": [], "permission": "allow" },
+    "echo": {
+      "program": "/bin/echo",
+      "effect": "read",
+      "allowedArgs": ["-n"],
+      "permission": "allow"
+    },
+    "cat": {
+      "program": "/bin/cat",
+      "effect": "read",
+      "allowedArgs": ["-n", "-b", "-s"],
+      "permission": "allow"
+    },
+    "head": {
+      "program": "/usr/bin/head",
+      "effect": "read",
+      "allowedArgs": ["-n", "-c"],
+      "permission": "allow"
+    },
+    "tail": {
+      "program": "/usr/bin/tail",
+      "effect": "read",
+      "allowedArgs": ["-n", "-c"],
+      "permission": "allow"
+    },
+    "wc": {
+      "program": "/usr/bin/wc",
+      "effect": "read",
+      "allowedArgs": ["-l", "-w", "-c", "-m"],
+      "permission": "allow"
+    },
+    "grep": {
+      "program": "/usr/bin/grep",
+      "effect": "read",
+      "allowedArgs": ["-i", "-n", "-v", "-c", "-l", "-w", "-x", "-E", "-F", "-r", "-A", "-B", "-C"],
+      "permission": "allow"
+    }
+  },
+
+  "_commands_note": "Argument allowlists, never denylists. A command declaring no allowedArgs accepts no arguments. grep -R and -S are excluded: both follow symbolic links during traversal on at least one implementation, reaching outside a root. -r does not.",
+
+  "_adding_note": "find, git, rm and every interpreter are ABSENT by default. find -fprintf writes attacker-chosen content while declared read; git executes commands from local .git/config and no environment variable disables it; interpreters take inline code. Add one only if you accept that.",
+
+  "deniedCommands": [],
+  "maxOutputBytes": 1048576,
+  "timeoutMs": 30000,
+  "maxConcurrent": 4
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,48 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2026-08-29
+
+### Security
+
+Fixes two vulnerability classes reported by four independent researchers.
+
+- **CWE-862 — self-approval** (`GHSA-q7hh-g47q-hwqj`, Taran-Douley). The agent held the tools that approved its own requests, and the whitelist was mutable at runtime, so any client could promote a forbidden command to `safe`.
+- **CWE-78 — shell injection** (`GHSA-2h3j-235x-vx2q` hackwither; `GHSA-8qwq-gwp3-g5h7` infosec-traceforce; `GHSA-h926-3g54-mr3v` bebold6133). `execFile` was called with a `shell` option, so arguments were concatenated into a shell command line and re-parsed.
+
+### BREAKING
+
+- Removed seven tools: `add_to_whitelist`, `update_security_level`, `remove_from_whitelist`, `approve_command`, `deny_command`, `get_pending_commands`, `get_whitelist`. No tool mutates policy; they are absent rather than gated.
+- Runtime whitelist edits are replaced by a config file read once at startup.
+- The default command set is now `ls pwd echo cat head tail wc grep`. `find`, `git` and every interpreter must be added deliberately.
+
+### Added
+
+- `get_policy` and `suggest_policy_config`
+- `execute_external_command` as the sole route outside configured roots
+- Configured roots, program directories, argument allowlists and per-command permissions
+- Append-only audit log, bounded by rotation
+- MCPB manifest and a sample configuration file
+
+### Changed
+
+- `execFile` is never given a `shell` option
+- The child environment is constructed rather than inherited
+- Programs resolve from configured program directories and are matched by resolved path, not basename
+- Scope covers the working directory as well as path-shaped arguments
+- Protection keys on the operation a request performs, not a declared effect
+- Exit codes are preserved: a `grep` with no match is a normal result, not an error
+- Output is capped by stopping collection; execution and concurrency are bounded
+- TypeScript 6.0.3, MCP SDK 1.30, zod 4, ESLint 10, Jest 30
+
+### Removed
+
+- Delete support. `rm` was `FORBIDDEN` in 1.x, so this is zero regression. The git-aware recoverability design is preserved in `openspec/deferred/delete-safety-2.1.md`.
+
 ## [1.1.0] - 2025-01-25
 
 ### Added
+
 - ESLint and Prettier configuration for code quality and formatting
 - Comprehensive documentation files:
   - LICENSE (MIT)
@@ -21,11 +60,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - .claude directory to .gitignore
 
 ### Changed
+
 - Fixed all TypeScript linting warnings (replaced `any` with `unknown`)
 - Updated Jest configuration to fix ESM module warnings
 - Enhanced package.json with complete metadata
 
 ### Fixed
+
 - TypeScript type safety improvements in command handlers
 
 ## [1.0.4] - 2025-03-12

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,7 @@ COPY package*.json ./
 COPY tsconfig.json ./
 
 # Install dependencies
-RUN npm ci --only=production && \
-    npm ci --only=development
+RUN npm ci
 
 # Copy source code
 COPY src/ ./src/
@@ -48,8 +47,7 @@ WORKDIR /app
 COPY package*.json ./
 
 # Install only production dependencies
-RUN npm ci --only=production && \
-    npm cache clean --force
+RUN npm ci --omit=dev && npm cache clean --force
 
 # Copy built application from builder
 COPY --from=builder /app/build ./build
@@ -67,14 +65,17 @@ USER mcpuser
 # Set environment variables
 ENV NODE_ENV=production
 ENV MCP_SERVER_NAME=mac-shell-mcp
+# A container starts with built-in defaults and NO roots, so it refuses every
+# request until a policy is supplied. Mount one and point at it:
+#   docker run -v $PWD/policy.json:/etc/mac-shell-mcp.json:ro \
+#              -e MAC_SHELL_MCP_CONFIG=/etc/mac-shell-mcp.json mac-shell-mcp
+ENV MAC_SHELL_MCP_CONFIG=/etc/mac-shell-mcp.json
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
     CMD node -e "process.exit(0)" || exit 1
 
-# Expose the default MCP stdio interface
-# Note: MCP servers typically communicate via stdio, not network ports
-EXPOSE 3000
+# No port is exposed: this server speaks MCP over stdio.
 
 # Start the MCP server
 CMD ["node", "build/index.js"]

--- a/README.md
+++ b/README.md
@@ -1,363 +1,136 @@
-[![MseeP.ai Security Assessment Badge](https://mseep.net/pr/cfdude-mac-shell-mcp-badge.png)](https://mseep.ai/app/cfdude-mac-shell-mcp)
-
 # Mac Shell MCP Server
 
-An MCP (Model Context Protocol) server for executing macOS terminal commands with ZSH shell. This server provides a secure way to execute shell commands with built-in whitelisting and approval mechanisms.
+[![CI](https://github.com/cfdude/mac-shell-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/cfdude/mac-shell-mcp/actions/workflows/ci.yml)
+[![Security Scans](https://github.com/cfdude/mac-shell-mcp/actions/workflows/security.yml/badge.svg)](https://github.com/cfdude/mac-shell-mcp/actions/workflows/security.yml)
 
-<a href="https://glama.ai/mcp/servers/@cfdude/mac-shell-mcp">
-  <img width="380" height="200" src="https://glama.ai/mcp/servers/@cfdude/mac-shell-mcp/badge" alt="Mac Shell Server MCP server" />
-</a>
+An MCP server that lets an AI client run a **small, fixed set of read-only shell commands**, confined to directories you nominate.
 
-## Features
+It is built around one idea: **the agent cannot widen its own authority.** There is no tool that edits the policy, no approval queue the agent can drain, and no shell to interpret its arguments.
 
-- Execute macOS terminal commands through MCP
-- Command whitelisting with security levels:
-  - **Safe**: Commands that can be executed without approval
-  - **Requires Approval**: Commands that need explicit approval before execution
-  - **Forbidden**: Commands that are explicitly blocked
-- Pre-configured whitelist with common safe commands
-- Approval workflow for potentially dangerous commands
-- Comprehensive command management tools
+> **Upgrading from 1.x?** 2.0.0 is a breaking change. Seven tools were removed and the authorization model was replaced. See [Migrating from 1.x](#migrating-from-1x). 1.x contained two vulnerabilities reported by four independent researchers; see the [security advisories](https://github.com/cfdude/mac-shell-mcp/security/advisories).
 
-## Installation
+## What it does
 
-```bash
-# Clone the repository
-git clone https://github.com/cfdude/mac-shell-mcp.git
-cd mac-shell-mcp
+| Tool                       | What it is for                                                    |
+| -------------------------- | ----------------------------------------------------------------- |
+| `execute_command`          | Run a permitted command **inside** your configured directories    |
+| `execute_external_command` | Run one **outside** them — requires a client that can ask a human |
+| `execute_pipeline`         | Chain read-only commands, stdout to stdin, without a shell        |
+| `get_policy`               | Ask what is permitted, rather than guessing and being refused     |
+| `suggest_policy_config`    | Turn observed usage into config **you** apply                     |
 
-# Install dependencies
-npm install
+## Default commands
 
-# Build the project
-npm run build
-```
+`ls` `pwd` `echo` `cat` `head` `tail` `wc` `grep`
 
-## Usage
+Each is restricted to an allowlist of flags. None of them can write a file, execute another program, or read configuration from the environment.
 
-### Starting the Server
+**`find`, `git`, `rm` and every interpreter are absent by default.** You can add any of them, and should know why they are not there:
+
+- `find -fprintf` writes attacker-chosen content to an attacker-chosen path, while `find` is naturally classified read-only
+- `git` executes commands from a repository's own `.git/config`, and no environment variable disables that
+- interpreters (`python`, `perl`, `awk`, `node`, `osascript`, …) take inline code as an argument
+
+## Install
 
 ```bash
-npm start
+npm install -g @cfdude/mac-shell-mcp
 ```
 
-Or directly:
+Then create a policy:
 
 ```bash
-node build/index.js
+mkdir -p ~/.mac-shell-mcp
+cp .mac-shell-mcp.sample.json ~/.mac-shell-mcp/config.json
+$EDITOR ~/.mac-shell-mcp/config.json    # set allowedRoots to your project
+chmod 444 ~/.mac-shell-mcp/config.json  # defence in depth; see Security
 ```
 
-### Configuring in Roo Code and Claude Desktop
-
-Both Roo Code and Claude Desktop use a similar configuration format for MCP servers. Here's how to set up the Mac Shell MCP server:
-
-#### Using Local Installation
-
-##### Roo Code Configuration
-
-Add the following to your Roo Code MCP settings configuration file (located at `~/Library/Application Support/Code/User/globalStorage/rooveterinaryinc.roo-cline/settings/cline_mcp_settings.json`):
-
-```json
-"mac-shell": {
-  "command": "node",
-  "args": [
-    "/path/to/mac-shell-mcp/build/index.js"
-  ],
-  "alwaysAllow": [],
-  "disabled": false
-}
-```
-
-##### Claude Desktop Configuration
-
-Add the following to your Claude Desktop configuration file (located at `~/Library/Application Support/Claude/claude_desktop_config.json`):
-
-```json
-"mac-shell": {
-  "command": "node",
-  "args": [
-    "/path/to/mac-shell-mcp/build/index.js"
-  ],
-  "alwaysAllow": false,
-  "disabled": false
-}
-```
-
-Replace `/path/to/mac-shell-mcp` with the actual path where you cloned the repository.
-
-#### Using NPX (Recommended)
-
-For a more convenient setup that doesn't require keeping a terminal window open, you can publish the package to npm and use it with npx:
-
-##### Publishing to npm
-
-1. Update the package.json with your details
-2. Publish to npm:
-   ```bash
-   npm publish
-   ```
-
-##### Roo Code Configuration
-
-```json
-"mac-shell": {
-  "command": "npx",
-  "args": [
-    "-y",
-    "mac-shell-mcp"
-  ],
-  "alwaysAllow": [],
-  "disabled": false
-}
-```
-
-##### Claude Desktop Configuration
-
-```json
-"mac-shell": {
-  "command": "npx",
-  "args": [
-    "-y",
-    "mac-shell-mcp"
-  ],
-  "alwaysAllow": false,
-  "disabled": false
-}
-```
-
-This approach allows the MCP server to be started automatically by the MCP client without requiring a separate terminal window or manual intervention.
-
-> **Note**:
-> - For Roo Code: Setting `alwaysAllow` to an empty array `[]` is recommended for security reasons, as it will prompt for approval before executing any commands. If you want to allow specific commands without prompting, you can add their names to the array, for example: `"alwaysAllow": ["execute_command", "get_whitelist"]`.
-> - For Claude Desktop: Setting `alwaysAllow` to `false` is recommended for security reasons. Claude Desktop uses a boolean value instead of an array, where `false` means all commands require approval and `true` means all commands are allowed without prompting.
->
-> **Important**: The `alwaysAllow` parameter is processed by the MCP client (Roo Code or Claude Desktop), not by the Mac Shell MCP server itself. The server will work correctly with either format, as the client handles the approval process before sending requests to the server.
-
-### Available Tools
-
-The server exposes the following MCP tools:
-
-#### `execute_command`
-
-Execute a shell command on macOS.
+Add to your MCP client:
 
 ```json
 {
-  "command": "ls",
-  "args": ["-la"]
+  "mcpServers": {
+    "mac-shell": { "command": "npx", "args": ["-y", "@cfdude/mac-shell-mcp"] }
+  }
 }
 ```
 
-#### `get_whitelist`
+**A fresh install with no roots configured refuses everything** — deliberately. Each refusal names the permitted commands and where configuration lives, so the first failure tells you what to do.
 
-Get the list of whitelisted commands.
+## Configuration
 
-```json
-{}
-```
+Policy is found in this order, first match wins, never merged:
 
-#### `add_to_whitelist`
+1. `$MAC_SHELL_MCP_CONFIG` — an explicit path
+2. `~/.mac-shell-mcp/config.json`
+3. Host environment (`MAC_SHELL_ROOTS`, `MAC_SHELL_COMMANDS`)
+4. Built-in defaults
 
-Add a command to the whitelist.
+**Policy is never read from the working directory.** A cloned repository must not be able to supply the policy governing the agent that opens it.
 
-```json
+```jsonc
 {
-  "command": "python3",
-  "securityLevel": "safe",
-  "description": "Run Python 3 scripts"
+  "allowedRoots": ["/Users/you/Projects/my-project"],
+  "programDirectories": ["/usr/bin", "/bin", "/usr/sbin", "/sbin"],
+  "commands": {
+    "grep": {
+      "program": "/usr/bin/grep",
+      "effect": "read",
+      "allowedArgs": ["-i", "-n", "-r", "-l", "-E", "-F"],
+      "permission": "allow",
+    },
+  },
 }
 ```
 
-#### `update_security_level`
+`permission` is `allow`, `ask`, or `deny`. **`ask` requires a client offering MCP `elicitation`** — the only capability that means a human can be asked. Where it is absent, `ask` becomes `deny`, never `allow`.
 
-Update the security level of a whitelisted command.
+## How it decides
 
-```json
-{
-  "command": "python3",
-  "securityLevel": "requires_approval"
-}
+**Authorization is `effect × scope`, computed per call.** `grep` inside your project is free; the same `grep` against `~/.aws` is not. The command name alone never decides.
+
+- **No shell.** `execFile` is never given a `shell` option, so arguments reach the OS uninterpreted. Nothing evaluates `;`, `$()`, or backticks — which is also why filenames with spaces, parentheses and brackets work normally.
+- **The program is authorized, not just the arguments.** Commands resolve to an absolute path from your program directories, are matched by that resolved path rather than by basename, and are refused if they resolve inside one of your roots. Roots hold data, never code.
+- **The environment is constructed, not inherited**, so a variable like `RIPGREP_CONFIG_PATH` cannot smuggle in a helper program that never appears in the argument list.
+- **Allowlists, never denylists.** A denylist is a list of the flags somebody thought of.
+- **Scope includes the working directory**, so a command with no path argument is judged by where it runs rather than passing because it named nothing.
+
+## Security
+
+The policy file, its parent directories, your program directories, and the whole audit log directory are **protected locations** — the server refuses to modify any of them, judged by the operation a request performs rather than by a command's declared effect. This is enforced in code, keyed on filesystem identity rather than path strings, and cannot be switched off from the policy file.
+
+`chmod 444` on your config is worth doing as a second, independent layer. It is not the mechanism: replacing a file needs write permission on its _directory_, not the file.
+
+Every request, permitted or refused, is recorded to an append-only audit log.
+
+**Known limits**, stated rather than implied — see [SECURITY.md](SECURITY.md):
+
+- Path detection is heuristic, and fails closed
+- Everything inside a root is freely readable by one recursive search
+- `ask` is only as strong as the host's approval prompt
+- Flag meanings vary between implementations of the same command name
+
+Report vulnerabilities via [private advisory](https://github.com/cfdude/mac-shell-mcp/security/advisories/new) or `security@onvex.ai`.
+
+## Migrating from 1.x
+
+**Removed:** `add_to_whitelist`, `update_security_level`, `remove_from_whitelist`, `approve_command`, `deny_command`, `get_pending_commands`, `get_whitelist`.
+
+The first three let any client promote a forbidden command to `safe`. The next three formed an approval workflow the requesting agent could drain by itself. `get_whitelist` is replaced by `get_policy`.
+
+Runtime whitelist edits become a config file you edit and the server reads at startup. `rm` was `FORBIDDEN` in 1.x and remains unavailable, so nothing that worked before stops working.
+
+## Development
+
+```bash
+npm install && npm run build
+npm test          # run it twice; a suite that only passes once is not passing
+npm run lint && npm run format:check
 ```
 
-#### `remove_from_whitelist`
-
-Remove a command from the whitelist.
-
-```json
-{
-  "command": "python3"
-}
-```
-
-#### `get_pending_commands`
-
-Get the list of commands pending approval.
-
-```json
-{}
-```
-
-#### `approve_command`
-
-Approve a pending command.
-
-```json
-{
-  "commandId": "command-uuid-here"
-}
-```
-
-#### `deny_command`
-
-Deny a pending command.
-
-```json
-{
-  "commandId": "command-uuid-here",
-  "reason": "This command is potentially dangerous"
-}
-```
-
-## Default Whitelisted Commands
-
-### Safe Commands (No Approval Required)
-
-- `ls` - List directory contents
-- `pwd` - Print working directory
-- `echo` - Print text to standard output
-- `cat` - Concatenate and print files
-- `grep` - Search for patterns in files
-- `find` - Find files in a directory hierarchy
-- `cd` - Change directory
-- `head` - Output the first part of files
-- `tail` - Output the last part of files
-- `wc` - Print newline, word, and byte counts
-
-### Commands Requiring Approval
-
-- `mv` - Move (rename) files
-- `cp` - Copy files and directories
-- `mkdir` - Create directories
-- `touch` - Change file timestamps or create empty files
-- `chmod` - Change file mode bits
-- `chown` - Change file owner and group
-
-### Forbidden Commands
-
-- `rm` - Remove files or directories
-- `sudo` - Execute a command as another user
-
-## Security Considerations
-
-> **⚠️ Accuracy note (2026-08-28).** This section previously claimed that forbidden commands
-> are never executed and that the server "uses Node.js's `execFile` instead of `exec` to prevent
-> shell injection". **Neither claim holds in 1.x.** They have been removed rather than restated,
-> because external reporters reasonably relied on them. Treat 1.x as providing no meaningful
-> sandbox, and see [SECURITY.md](SECURITY.md) plus the repository's
-> [security advisories](https://github.com/cfdude/mac-shell-mcp/security/advisories).
-
-- All commands are executed with the permissions of the user running the MCP server
-- Commands requiring approval are held in a queue until approved — **but the approval tools are
-  exposed to the same client that makes the request, so this is not an enforced control in 1.x**
-- The command whitelist is mutable at runtime by any connected client, so the "forbidden" tier
-  is advisory rather than binding in 1.x
-- Arguments are validated against allowed patterns when specified
-
-A redesign that makes these guarantees real ships in 2.0.0 — see
-[the design spec](docs/superpowers/specs/2026-08-13-mac-shell-mcp-2.0-security-redesign.md).
-
-## Extending the Whitelist
-
-You can extend the whitelist by using the `add_to_whitelist` tool. For example:
-
-```json
-{
-  "command": "npm",
-  "securityLevel": "requires_approval",
-  "description": "Node.js package manager"
-}
-```
-
-## Using as an npm Package
-
-To use the Mac Shell MCP server with `npx` similar to other MCP servers like Brave Search, you can publish it to npm or use it directly from GitHub.
-
-### Configuration with npx
-
-Add the following to your MCP settings configuration:
-
-#### Roo Code
-```json
-"mac-shell": {
-  "command": "npx",
-  "args": [
-    "-y",
-    "github:cfdude/mac-shell-mcp"
-  ],
-  "alwaysAllow": [],
-  "disabled": false
-}
-```
-
-#### Claude Desktop
-```json
-"mac-shell": {
-  "command": "npx",
-  "args": [
-    "-y",
-    "github:cfdude/mac-shell-mcp"
-  ],
-  "alwaysAllow": false,
-  "disabled": false
-}
-```
-
-This will automatically download and run the server without requiring a manual clone and build process.
-
-### Publishing to npm
-
-If you want to publish your own version to npm:
-
-1. Update the package.json with your details
-2. Add a "bin" field to package.json:
-   ```json
-   "bin": {
-     "mac-shell-mcp": "./build/index.js"
-   }
-   ```
-3. Publish to npm:
-   ```bash
-   npm publish
-   ```
-
-Then you can use it in your MCP configuration:
-
-#### Roo Code
-```json
-"mac-shell": {
-  "command": "npx",
-  "args": [
-    "-y",
-    "mac-shell-mcp"
-  ],
-  "alwaysAllow": [],
-  "disabled": false
-}
-```
-
-#### Claude Desktop
-```json
-"mac-shell": {
-  "command": "npx",
-  "args": [
-    "-y",
-    "mac-shell-mcp"
-  ],
-  "alwaysAllow": false,
-  "disabled": false
-}
-```
+Design and specifications: `openspec/changes/mac-shell-mcp-2-security-redesign/`.
 
 ## License
 
-This MCP server is licensed under the MIT License. This means you are free to use, modify, and distribute the software, subject to the terms and conditions of the MIT License. For more details, please see the LICENSE file in the project repository.
+MIT — see [LICENSE](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,8 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 1.1.x   | :white_check_mark: |
-| < 1.1   | :x:                |
+| 2.0.x   | :white_check_mark: |
+| < 2.0   | :x:                |
 
 ## Reporting a Vulnerability
 
@@ -24,41 +24,40 @@ The Mac Shell MCP server executes system commands and takes security seriously. 
 
 We will acknowledge your email within 48 hours and provide a detailed response within 7 days.
 
-## Security Features
+## Security Model
 
-This MCP server implements several security measures:
-
-- **Command Whitelisting**: Only pre-approved commands can be executed
-- **Security Levels**: Commands are categorized as safe, requires approval, or forbidden
-- **User Permissions**: Commands run with the permissions of the MCP server user
-
-> **Accuracy note (2026-08-28).** Earlier versions of this document claimed
-> "No Shell Injection: Uses `execFile` instead of `exec` to prevent injection attacks"
-> and described the approval workflow as an enforced control. **Neither claim holds in
-> 1.x**, and both have been removed rather than restated. Treat 1.x as providing no
-> meaningful sandbox. A redesign correcting this ships in 2.0.0; see
-> `docs/superpowers/specs/2026-08-13-mac-shell-mcp-2.0-security-redesign.md`.
+- **No shell.** `execFile` is never given a `shell` option, so arguments reach the OS uninterpreted.
+- **The child environment is constructed**, not inherited, so a configuration variable cannot name a helper program that never appears in the argument list.
+- **Programs are authorized**, not only arguments: resolved from configured program directories, matched by resolved path rather than basename, and refused if they resolve inside a configured root.
+- **Argument allowlists, never denylists.** A command declaring no allowed arguments accepts none.
+- **Confinement.** Authorization is effect crossed with scope, computed per call, where scope covers the working directory as well as every path-shaped argument.
+- **No tool mutates policy.** Policy is read once at startup and is immutable for the process lifetime.
+- **Protected locations.** The policy file, its ancestors, the program directories and the whole audit log directory cannot be modified by this server, judged by the operation a request performs rather than a command's declared effect.
+- **Append-only audit log** of every request, permitted or refused.
 
 ## Best Practices
 
 When using this MCP server:
 
-1. **Review the whitelist** regularly and remove unnecessary commands
-2. **Set appropriate security levels** for commands based on your use case
+1. **Keep `allowedRoots` narrow** — everything inside a root is readable by one recursive search
+2. **Add `find`, `git` or an interpreter only deliberately** — each can execute or write in ways the model cannot constrain
 3. **Never run the server with elevated privileges** (e.g., sudo)
-4. **Do not rely on the 1.x approval workflow as a security boundary** — configure your
-   MCP client to prompt for tool calls instead
+4. **Configure your MCP client to prompt for `execute_external_command`** — it is the only route outside your configured directories
 5. **Keep the server updated** to receive security patches
 
 ## Known Limitations
 
-- Commands execute with the full permissions of the user running the server
-- **In 1.x the approval mechanism is not an enforced control** and must not be treated as one
-- File system access is limited only by OS permissions — 1.x does not confine commands to any directory
-- Unfixed vulnerabilities in 1.x are tracked in this repository's
-  [security advisories](https://github.com/cfdude/mac-shell-mcp/security/advisories)
+Stated rather than implied. None of these is hidden by the design:
+
+- **Path detection is heuristic.** Deciding which arguments are paths cannot be perfect; ambiguous arguments fail closed, which over-prompts rather than under-protects.
+- **Everything inside a root is freely readable.** A single recursive search returns anything in a configured directory, so a root should be a project directory, not your home folder. The server refuses `$HOME` and `/` outright and reports a root containing `.ssh`, `.aws`, `.env`, `.npmrc` or `.git/config`.
+- **The policy file is a single point of trust.** This server cannot modify it, and `chmod 444` raises the bar further, but a separate process running as the same user can. That is inherent to file-based configuration.
+- **`ask` is only as strong as the host.** It resolves to the client's approval prompt, so a host configured to always-allow converts every `ask` into `allow`. Without MCP `elicitation`, `ask` becomes `deny`.
+- **`execute_external_command` is inert without `elicitation`.** On a host that does not offer it — including the primary target — out-of-root work is unavailable rather than silently permitted.
+- **Flag meanings vary between implementations.** `grep -R` follows symbolic links under one implementation and not another, so commands are pinned to an expected program path and flag allowlists are authored for that program.
+- **Commands run with the full permissions of the user running the server.** There is no sandbox.
+- **No delete capability.** `rm` is unavailable, as it was in 1.x.
 
 ## Distribution
 
-The npm package named `mac-shell-mcp` is **not published by this project** and is not under
-its control. Install from this repository until an officially published package is announced.
+The npm package named `mac-shell-mcp` is **not published by this project** and is not under its control. Install `@cfdude/mac-shell-mcp`, or from this repository.

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,81 @@
+{
+  "manifest_version": "0.4",
+  "name": "mac-shell-mcp",
+  "display_name": "Mac Shell",
+  "version": "2.0.0",
+  "description": "Run a small set of read-only shell commands, confined to directories you choose.",
+  "long_description": "Exposes a deliberately small set of commands (ls, pwd, echo, cat, head, tail, wc, grep) confined to directories you nominate. No shell is ever invoked, the child environment is constructed rather than inherited, and no tool can change the policy at runtime. find, git, rm and interpreters are absent by default.",
+  "author": {
+    "name": "Rob Sherman",
+    "url": "https://github.com/cfdude"
+  },
+  "homepage": "https://github.com/cfdude/mac-shell-mcp",
+  "documentation": "https://github.com/cfdude/mac-shell-mcp#readme",
+  "support": "https://github.com/cfdude/mac-shell-mcp/issues",
+  "license": "MIT",
+  "keywords": ["shell", "macos", "terminal", "security"],
+  "server": {
+    "type": "node",
+    "entry_point": "build/index.js",
+    "mcp_config": {
+      "command": "node",
+      "args": ["${__dirname}/build/index.js"],
+      "env": {
+        "MAC_SHELL_ROOTS": "${user_config.allowed_roots}",
+        "MAC_SHELL_COMMANDS": "${user_config.allowed_commands}",
+        "MAC_SHELL_AUDIT_DIR": "${user_config.audit_log_dir}"
+      }
+    }
+  },
+  "tools": [
+    {
+      "name": "execute_command",
+      "description": "Run a permitted command confined to the configured roots."
+    },
+    {
+      "name": "execute_external_command",
+      "description": "Run a permitted command outside the roots. Requires an interactive client."
+    },
+    {
+      "name": "execute_pipeline",
+      "description": "Compose read-only commands, wiring stdout to stdin in process."
+    },
+    {
+      "name": "get_policy",
+      "description": "Report the effective policy."
+    },
+    {
+      "name": "suggest_policy_config",
+      "description": "Summarize recorded usage into configuration a human may apply."
+    }
+  ],
+  "user_config": {
+    "allowed_roots": {
+      "type": "directory",
+      "title": "Allowed directories",
+      "description": "Directories the agent may work in. Everything inside one is freely readable, so choose project directories rather than your home folder.",
+      "multiple": true,
+      "required": false,
+      "default": []
+    },
+    "allowed_commands": {
+      "type": "string",
+      "title": "Allowed commands",
+      "description": "Comma-separated. Defaults to a read-only set that cannot write, execute, or read configuration.",
+      "required": false,
+      "default": "ls,pwd,echo,cat,head,tail,wc,grep"
+    },
+    "audit_log_dir": {
+      "type": "directory",
+      "title": "Audit log directory",
+      "description": "Where the record of every command is written. Protected from modification by the server itself.",
+      "required": false
+    }
+  },
+  "compatibility": {
+    "platforms": ["darwin"],
+    "runtimes": {
+      "node": ">=18.0.0"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "mac-shell-mcp",
+  "name": "@cfdude/mac-shell-mcp",
   "version": "2.0.0",
   "description": "MCP server for macOS shell access, confined to configured roots with no shell interpretation",
   "type": "module",
@@ -8,7 +8,9 @@
     "mac-shell-mcp": "./build/index.js"
   },
   "files": [
-    "build"
+    "build",
+    ".mac-shell-mcp.sample.json",
+    "manifest.json"
   ],
   "scripts": {
     "build": "tsc && chmod +x build/index.js",

--- a/smithery.json
+++ b/smithery.json
@@ -1,151 +1,119 @@
 {
   "name": "mac-shell-mcp",
-  "description": "An MCP server for executing macOS terminal commands with ZSH shell, featuring secure command whitelisting and approval mechanisms",
+  "description": "MCP server for macOS shell access, confined to configured roots with no shell interpretation",
   "author": "Rob Sherman",
   "license": "MIT",
   "repository": "https://github.com/cfdude/mac-shell-mcp",
   "homepage": "https://github.com/cfdude/mac-shell-mcp#readme",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "categories": ["productivity", "automation", "terminal", "macos"],
-  "keywords": ["mcp", "shell", "macos", "zsh", "terminal", "command-line", "automation"],
+  "keywords": ["mcp", "shell", "macos", "terminal", "security"],
   "requirements": {
     "node": ">=18.0.0",
     "platform": ["darwin"]
   },
   "installation": {
     "type": "npm",
-    "package": "mac-shell-mcp"
+    "package": "@cfdude/mac-shell-mcp"
   },
   "configuration": {
     "claude": {
       "command": "npx",
-      "args": ["-y", "mac-shell-mcp"],
+      "args": ["-y", "@cfdude/mac-shell-mcp"],
       "alwaysAllow": false
     },
     "roo": {
       "command": "npx",
-      "args": ["-y", "mac-shell-mcp"],
+      "args": ["-y", "@cfdude/mac-shell-mcp"],
       "alwaysAllow": []
     }
   },
   "tools": [
     {
       "name": "execute_command",
-      "description": "Execute a shell command on macOS",
+      "description": "Run a permitted command confined to the configured roots",
       "parameters": {
         "command": {
           "type": "string",
-          "description": "The command to execute",
           "required": true
         },
         "args": {
           "type": "array",
-          "description": "Command arguments",
+          "required": false
+        },
+        "cwd": {
+          "type": "string",
+          "required": false
+        },
+        "stdin": {
+          "type": "string",
           "required": false
         }
       }
     },
     {
-      "name": "get_whitelist",
-      "description": "Get the list of whitelisted commands",
+      "name": "execute_external_command",
+      "description": "Run a permitted command outside the roots; requires an interactive client",
+      "parameters": {
+        "command": {
+          "type": "string",
+          "required": true
+        },
+        "args": {
+          "type": "array",
+          "required": false
+        },
+        "cwd": {
+          "type": "string",
+          "required": false
+        }
+      }
+    },
+    {
+      "name": "execute_pipeline",
+      "description": "Compose read-only commands, wiring stdout to stdin in process",
+      "parameters": {
+        "stages": {
+          "type": "array",
+          "required": true
+        },
+        "cwd": {
+          "type": "string",
+          "required": false
+        }
+      }
+    },
+    {
+      "name": "get_policy",
+      "description": "Report the effective policy",
       "parameters": {}
     },
     {
-      "name": "add_to_whitelist",
-      "description": "Add a command to the whitelist",
-      "parameters": {
-        "command": {
-          "type": "string",
-          "description": "The command to whitelist",
-          "required": true
-        },
-        "securityLevel": {
-          "type": "string",
-          "description": "Security level: safe, requires_approval, or forbidden",
-          "required": true
-        },
-        "description": {
-          "type": "string",
-          "description": "Description of the command",
-          "required": false
-        }
-      }
-    },
-    {
-      "name": "update_security_level",
-      "description": "Update the security level of a whitelisted command",
-      "parameters": {
-        "command": {
-          "type": "string",
-          "description": "The command to update",
-          "required": true
-        },
-        "securityLevel": {
-          "type": "string",
-          "description": "New security level",
-          "required": true
-        }
-      }
-    },
-    {
-      "name": "remove_from_whitelist",
-      "description": "Remove a command from the whitelist",
-      "parameters": {
-        "command": {
-          "type": "string",
-          "description": "The command to remove",
-          "required": true
-        }
-      }
-    },
-    {
-      "name": "get_pending_commands",
-      "description": "Get the list of commands pending approval",
+      "name": "suggest_policy_config",
+      "description": "Summarize recorded usage into configuration a human may apply",
       "parameters": {}
-    },
-    {
-      "name": "approve_command",
-      "description": "Approve a pending command",
-      "parameters": {
-        "commandId": {
-          "type": "string",
-          "description": "The ID of the command to approve",
-          "required": true
-        }
-      }
-    },
-    {
-      "name": "deny_command",
-      "description": "Deny a pending command",
-      "parameters": {
-        "commandId": {
-          "type": "string",
-          "description": "The ID of the command to deny",
-          "required": true
-        },
-        "reason": {
-          "type": "string",
-          "description": "Reason for denial",
-          "required": false
-        }
-      }
     }
   ],
   "environment": {
-    "MAC_SHELL_SAFE_MODE": {
-      "type": "boolean",
-      "description": "Enable safe mode (restrict to safe commands only)",
-      "default": false
-    },
-    "MAC_SHELL_LOG_LEVEL": {
+    "MAC_SHELL_MCP_CONFIG": {
       "type": "string",
-      "description": "Logging level (debug, info, warn, error)",
-      "default": "info"
+      "description": "Explicit path to a policy file. Takes precedence over the home config."
     },
-    "MAC_SHELL_APPROVAL_TIMEOUT": {
-      "type": "number",
-      "description": "Timeout for command approval in seconds",
-      "default": 300
+    "MAC_SHELL_ROOTS": {
+      "type": "string",
+      "description": "Comma-separated directories the agent may work in."
+    },
+    "MAC_SHELL_COMMANDS": {
+      "type": "string",
+      "description": "Comma-separated permitted commands."
+    },
+    "MAC_SHELL_AUDIT_DIR": {
+      "type": "string",
+      "description": "Directory for the audit log."
     }
+  },
+  "security": {
+    "notes": "No shell is invoked. The child environment is constructed rather than inherited. No tool mutates policy at runtime. find, git, rm and interpreters are absent by default.",
+    "advisories": "https://github.com/cfdude/mac-shell-mcp/security/advisories"
   }
 }


### PR DESCRIPTION
Follows #20. Brings the user-facing surface in line with what 2.0 actually ships.

- **README** documented seven tools that no longer exist and described the approval workflow as a real control. Rewritten — including *why* `find`, `git`, `rm` and interpreters are absent, since a user who doesn't know will add them straight back.
- **SECURITY.md** now states the model and the **known limits** plainly: heuristic path detection, everything inside a root freely readable, the policy file as a single point of trust, `ask` only as strong as the host, `execute_external_command` inert without `elicitation`, and flag semantics varying between implementations.
- **smithery.json** advertised all seven removed tools as the documented API.
- **manifest.json** (new) — `mcpb validate` passes; every field carrying a default is `required: false` so Claude Desktop auto-enables rather than installing disabled.
- **.mac-shell-mcp.sample.json** (new) — verified to parse through the real loader, not just valid JSON.
- **Dockerfile** — drops the misleading `EXPOSE 3000` (stdio binds no port), collapses the redundant double `npm ci`, documents that a container refuses everything until a policy is mounted.
- **Package renamed** to `@cfdude/mac-shell-mcp`; the bare name is held by a third party publishing this repo's 1.0.4 code with attribution stripped.

https://claude.ai/code/session_016DJQSrQW1fsrbYfy6H1xEU