### PR TITLE
fix: stale lockfile; parser-differential in the CI transport guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,11 +75,29 @@ jobs:
       # express/hono stack is never instantiated, so its advisories are
       # unreachable. If an HTTP or SSE transport is ever imported that argument
       # silently stops holding, so fail loudly instead.
+      # A regex over source text is not a parser: an import can be spelled in
+      # ways a path pattern will not match (string concatenation, dynamic
+      # import). So match the COMPONENT names rather than a full path, and check
+      # the built output as well as the source. This is a tripwire, not a proof
+      # -- SECURITY.md says so rather than implying completeness.
       - name: Refuse HTTP/SSE transports
         run: |
-          if grep -rnE "server/(streamableHttp|sse|express)\.js" src/; then
-            echo "::error::An HTTP/SSE transport was imported. This server is stdio-only;"
-            echo "::error::the dependency reachability argument in SECURITY.md no longer holds."
-            exit 1
-          fi
-          echo "stdio-only: confirmed"
+          set -euo pipefail
+          npm ci
+          npm run build
+          node -e "
+            const fs = require('fs');
+            const walk = (d) => fs.readdirSync(d, { withFileTypes: true })
+              .flatMap((e) => (e.isDirectory() ? walk(d + '/' + e.name) : [d + '/' + e.name]));
+            const PAT = /streamableHttp|sse\.js|server\/express|['\"]express['\"]/;
+            const hits = [...walk('src'), ...walk('build')]
+              .filter((f) => /\.(ts|js)\$/.test(f))
+              .filter((f) => PAT.test(fs.readFileSync(f, 'utf8')));
+            if (hits.length) {
+              console.error('::error::HTTP/SSE transport reference found in: ' + hits.join(', '));
+              console.error('::error::This server is stdio-only. The dependency reachability');
+              console.error('::error::argument in SECURITY.md no longer holds -- re-verify it.');
+              process.exit(1);
+            }
+            console.log('stdio-only: confirmed in source and built output');
+          "

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -57,6 +57,7 @@ Stated rather than implied. None of these is hidden by the design:
 - **Flag meanings vary between implementations.** `grep -R` follows symbolic links under one implementation and not another, so commands are pinned to an expected program path and flag allowlists are authored for that program.
 - **Commands run with the full permissions of the user running the server.** There is no sandbox.
 - **No delete capability.** `rm` is unavailable, as it was in 1.x.
+- **The stdio-only CI guard is a tripwire, not a proof.** The SDK's HTTP transports pull in a web-framework dependency tree whose advisories are unreachable here only because this server never instantiates them. CI fails if a transport reference appears in the source or built output, but it matches text rather than parsing a module graph, so a sufficiently indirect reference could evade it.
 
 ## Distribution
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "mac-shell-mcp",
-  "version": "1.1.0",
+  "name": "@cfdude/mac-shell-mcp",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "mac-shell-mcp",
-      "version": "1.1.0",
+      "name": "@cfdude/mac-shell-mcp",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.30",


### PR DESCRIPTION
Two defects introduced by the previous PRs, both found during verification.

**1. Stale lockfile.** `package.json` became `@cfdude/mac-shell-mcp @ 2.0.0` while `package-lock.json` still said `mac-shell-mcp @ 1.1.0`. `npm ci` then installed inconsistently — locally it left `typescript` absent and the build failed with `Cannot find type definition file for 'node'`.

**2. The transport guard could be evaded.** It matched a full path, so an import written as `'@modelcontextprotocol/sdk/server/' + 'sse.js'` never produced a contiguous match.

```
original pattern          → MISSED the concatenated form
+ built-output check      → MISSED it too (concatenation survives compilation)
component-name matching   → CAUGHT, and silent on a clean tree
```

`SECURITY.md` now states plainly that this guard is a **tripwire, not a proof** — it matches text rather than parsing a module graph. The whole dependency-reachability argument rests on this server staying stdio-only, so the guard's limits belong in writing rather than being implied away.

https://claude.ai/code/session_016DJQSrQW1fsrbYfy6H1xEU