### PR TITLE
chore(ci): pin TypeScript to major 6 in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,12 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    ignore:
+      # TypeScript 7 breaks @typescript-eslint/parser, whose peer range is
+      # >=4.8.4 <6.1.0. Dependabot proposed it, CI caught it. Revisit when
+      # typescript-eslint widens the range.
+      - dependency-name: typescript
+        update-types: ["version-update:semver-major"]
     groups:
       production:
         dependency-type: production


### PR DESCRIPTION
TypeScript 7 breaks `@typescript-eslint/parser` (peer `>=4.8.4 <6.1.0`). Dependabot proposed it in #24 and CI caught it — `lint` and all three `test` jobs failed. This stops the proposal recurring weekly.

Revisit when typescript-eslint widens its range.

https://claude.ai/code/session_016DJQSrQW1fsrbYfy6H1xEU