### PR TITLE
chore(npm): publish as @the_cfdude/mac-shell-mcp; fix bin path

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Each is restricted to an allowlist of flags. None of them can write a file, exec
 ## Install
 
 ```bash
-npm install -g @cfdude/mac-shell-mcp
+npm install -g @the_cfdude/mac-shell-mcp
 ```
 
 Then create a policy:
@@ -51,7 +51,7 @@ Add to your MCP client:
 ```json
 {
   "mcpServers": {
-    "mac-shell": { "command": "npx", "args": ["-y", "@cfdude/mac-shell-mcp"] }
+    "mac-shell": { "command": "npx", "args": ["-y", "@the_cfdude/mac-shell-mcp"] }
   }
 }
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -61,4 +61,4 @@ Stated rather than implied. None of these is hidden by the design:
 
 ## Distribution
 
-The npm package named `mac-shell-mcp` is **not published by this project** and is not under its control. Install `@cfdude/mac-shell-mcp`, or from this repository.
+The npm package named `mac-shell-mcp` is **not published by this project** and is not under its control. Install `@the_cfdude/mac-shell-mcp`, or from this repository.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@cfdude/mac-shell-mcp",
+  "name": "@the_cfdude/mac-shell-mcp",
   "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@cfdude/mac-shell-mcp",
+      "name": "@the_cfdude/mac-shell-mcp",
       "version": "2.0.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "@cfdude/mac-shell-mcp",
+  "name": "@the_cfdude/mac-shell-mcp",
   "version": "2.0.0",
   "description": "MCP server for macOS shell access, confined to configured roots with no shell interpretation",
   "type": "module",
   "main": "build/index.js",
   "bin": {
-    "mac-shell-mcp": "./build/index.js"
+    "mac-shell-mcp": "build/index.js"
   },
   "files": [
     "build",

--- a/smithery.json
+++ b/smithery.json
@@ -6,25 +6,44 @@
   "repository": "https://github.com/cfdude/mac-shell-mcp",
   "homepage": "https://github.com/cfdude/mac-shell-mcp#readme",
   "version": "2.0.0",
-  "categories": ["productivity", "automation", "terminal", "macos"],
-  "keywords": ["mcp", "shell", "macos", "terminal", "security"],
+  "categories": [
+    "productivity",
+    "automation",
+    "terminal",
+    "macos"
+  ],
+  "keywords": [
+    "mcp",
+    "shell",
+    "macos",
+    "terminal",
+    "security"
+  ],
   "requirements": {
     "node": ">=18.0.0",
-    "platform": ["darwin"]
+    "platform": [
+      "darwin"
+    ]
   },
   "installation": {
     "type": "npm",
-    "package": "@cfdude/mac-shell-mcp"
+    "package": "@the_cfdude/mac-shell-mcp"
   },
   "configuration": {
     "claude": {
       "command": "npx",
-      "args": ["-y", "@cfdude/mac-shell-mcp"],
+      "args": [
+        "-y",
+        "@the_cfdude/mac-shell-mcp"
+      ],
       "alwaysAllow": false
     },
     "roo": {
       "command": "npx",
-      "args": ["-y", "@cfdude/mac-shell-mcp"],
+      "args": [
+        "-y",
+        "@the_cfdude/mac-shell-mcp"
+      ],
       "alwaysAllow": []
     }
   },


### PR DESCRIPTION
The `@cfdude` scope belongs to a different npm account, so publishing returned `E404` — npm reports 404 rather than 403 for a scope you can't write to. The authenticated account is `the_cfdude`, whose personal scope is free.

Also drops the `./` prefix from the `bin` path. npm rejected `"./build/index.js"` as an invalid script name and **silently removed the bin entry**, which would have shipped a package whose command didn't exist.

https://claude.ai/code/session_016DJQSrQW1fsrbYfy6H1xEU